### PR TITLE
Test impl with service broker request objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.cloudfoundry</groupId>
+			<groupId>com.github.krujos</groupId>
 			<artifactId>spring-boot-cf-service-broker</artifactId>
-			<version>2.4.0</version>
+			<version>x5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.cloudfoundry</groupId>
@@ -90,6 +90,10 @@
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
+		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 		</repository>
 	</repositories>
 	<build>

--- a/src/main/java/io/pivotal/cdm/config/PostgresCatalogConfig.java
+++ b/src/main/java/io/pivotal/cdm/config/PostgresCatalogConfig.java
@@ -3,8 +3,7 @@ package io.pivotal.cdm.config;
 import java.util.*;
 
 import org.cloudfoundry.community.servicebroker.model.*;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.*;
 
 @Configuration
 public class PostgresCatalogConfig {

--- a/src/main/java/io/pivotal/cdm/service/PostgresServiceInstanceService.java
+++ b/src/main/java/io/pivotal/cdm/service/PostgresServiceInstanceService.java
@@ -1,11 +1,9 @@
 package io.pivotal.cdm.service;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.cloudfoundry.community.servicebroker.exception.*;
-import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
-import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
+import org.cloudfoundry.community.servicebroker.model.*;
 import org.cloudfoundry.community.servicebroker.service.ServiceInstanceService;
 import org.springframework.stereotype.Service;
 
@@ -22,13 +20,13 @@ public class PostgresServiceInstanceService implements ServiceInstanceService {
 	Map<String, ServiceInstance> instances = new HashMap<String, ServiceInstance>();
 
 	@Override
-	public ServiceInstance createServiceInstance(ServiceDefinition service,
-			String serviceInstanceId, String planId, String organizationGuid,
-			String spaceGuid) throws ServiceInstanceExistsException,
-			ServiceBrokerException {
-		ServiceInstance instance = new ServiceInstance(serviceInstanceId,
-				service.getId(), planId, organizationGuid, spaceGuid, null);
-		instances.put(serviceInstanceId, instance);
+	public ServiceInstance createServiceInstance(
+			CreateServiceInstanceRequest request)
+			throws ServiceInstanceExistsException, ServiceBrokerException {
+
+		ServiceInstance instance = new ServiceInstance(request)
+				.withDashboardUrl("http://www.google.com");
+		instances.put(request.getServiceInstanceId(), instance);
 		return instance;
 	}
 
@@ -48,18 +46,15 @@ public class PostgresServiceInstanceService implements ServiceInstanceService {
 			String planId) throws ServiceInstanceUpdateNotSupportedException,
 			ServiceBrokerException, ServiceInstanceDoesNotExistException {
 
-		ServiceInstance oldInstance = instances.get(instanceId);
-		if (null == oldInstance) {
+		ServiceInstance instance = instances.get(instanceId);
+		if (null == instance) {
 			throw new ServiceInstanceDoesNotExistException(instanceId);
 		}
 
-		instances.put(
-				instanceId,
-				new ServiceInstance(instanceId, oldInstance
-						.getServiceDefinitionId(), planId, oldInstance
-						.getOrganizationGuid(), oldInstance.getSpaceGuid(),
-						oldInstance.getDashboardUrl()));
+		instance.setPlanId(planId);
 
-		return instances.get(instanceId);
+		instances.put(instanceId, instance);
+
+		return instance;
 	}
 }

--- a/src/test/java/io/pivotal/cdm/service/PostgresServiceInstanceBindingServiceTest.java
+++ b/src/test/java/io/pivotal/cdm/service/PostgresServiceInstanceBindingServiceTest.java
@@ -1,22 +1,15 @@
 package io.pivotal.cdm.service;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import io.pivotal.cdm.aws.AWSHelper;
 
-import org.cloudfoundry.community.servicebroker.exception.ServiceBrokerException;
-import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceBindingExistsException;
-import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
-import org.cloudfoundry.community.servicebroker.model.ServiceInstanceBinding;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.cloudfoundry.community.servicebroker.exception.*;
+import org.cloudfoundry.community.servicebroker.model.*;
+import org.junit.*;
+import org.mockito.*;
 
 import com.amazonaws.services.ec2.AmazonEC2Client;
 
@@ -27,7 +20,9 @@ public class PostgresServiceInstanceBindingServiceTest {
 	private PostgresServiceInstanceBindingService bindingService;
 
 	private ServiceInstance serviceInstance = new ServiceInstance(
-			"test_service", "test_service_id", "copy", "1234", "4566", null);
+			new CreateServiceInstanceRequest("test_servicedef", "copy",
+					"test_org", "test_space")
+					.withServiceInstanceId("test_service_instance_id"));
 	private ServiceInstanceBinding bindResult;
 
 	@Before

--- a/src/test/java/io/pivotal/cdm/service/PostgresServiceInstanceServiceTest.java
+++ b/src/test/java/io/pivotal/cdm/service/PostgresServiceInstanceServiceTest.java
@@ -1,16 +1,12 @@
 package io.pivotal.cdm.service;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import io.pivotal.cdm.config.PostgresCatalogConfig;
-import io.pivotal.cdm.service.PostgresServiceInstanceService;
 
 import org.cloudfoundry.community.servicebroker.exception.*;
-import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
-import org.junit.Before;
-import org.junit.Test;
+import org.cloudfoundry.community.servicebroker.model.*;
+import org.junit.*;
 
 public class PostgresServiceInstanceServiceTest {
 
@@ -21,9 +17,12 @@ public class PostgresServiceInstanceServiceTest {
 	public void setUp() throws ServiceInstanceExistsException,
 			ServiceBrokerException {
 		service = new PostgresServiceInstanceService();
-		instance = service.createServiceInstance(new PostgresCatalogConfig()
-				.catalog().getServiceDefinitions().get(0),
-				"service_instance_id", "plan_id", "org_guid", "space_guid");
+		String definitionId = new PostgresCatalogConfig().catalog()
+				.getServiceDefinitions().get(0).getId();
+		CreateServiceInstanceRequest request = new CreateServiceInstanceRequest(
+				definitionId, "copy", "test_org", "test_space")
+				.withServiceInstanceId("service_instance_id");
+		instance = service.createServiceInstance(request);
 	}
 
 	@Test


### PR DESCRIPTION
Shows the effects of the change to the CF service broker for RequestObjects in consuming code. The code becomes conciser, with the advantage of IDE documentation popups for each method in the request object that can describe the intent of the parameter. 

The pattern is _Definition objects become mutable, the *Request objects are not. This allows implementors to track, extend or proxy the definition objects with low overhead, and in most cases ignore them all together by just construct them with a request object and using the .with_ methods where we intend for the broker's to provide / manufacture additional information (dashboard url's for example). 
